### PR TITLE
Add CSS variable for font fallback of specimen font(s)

### DIFF
--- a/codeGeneration.js
+++ b/codeGeneration.js
@@ -106,7 +106,7 @@ const buildVariationStyles = fontData => {
   rule.append(
     postcss.decl({
       prop: "font-family",
-      value: `"${fontData.name}", monospace`
+      value: `"${fontData.name}", var(--specimen-fallback-font, monospace), monospace`
     })
   );
 
@@ -126,7 +126,7 @@ const buildRegularStyles = fontData => {
   rule.append(
     postcss.decl({
       prop: "font-family",
-      value: `"${fontData.name}", monospace`
+      value: `"${fontData.name}", var(--specimen-fallback-font, monospace), monospace`
     })
   );
 

--- a/codeGeneration.test.js
+++ b/codeGeneration.test.js
@@ -177,7 +177,7 @@ describe("font variation settings", () => {
       .my-font *,
       .my-font *::before,
       .my-font *::after {
-          font-family: "My font", monospace;
+          font-family: "My font", var(--specimen-fallback-font, monospace), monospace;
           font-variation-settings: "wdth" var(--wdth),"wght" var(--wght)
       }
     `);
@@ -206,7 +206,7 @@ describe("stylesheet", () => {
       .my-font *,
       .my-font *::before,
       .my-font *::after {
-          font-family: "My font", monospace;
+          font-family: "My font", var(--specimen-fallback-font, monospace), monospace;
           font-variation-settings: "wdth" var(--wdth),"wght" var(--wght)
       }
     `);
@@ -219,7 +219,7 @@ describe("regular font", () => {
 
     expect(css).toEqual(stripIndent`
       .my-font {
-          font-family: "My font", monospace
+          font-family: "My font", var(--specimen-fallback-font, monospace), monospace
       }
     `);
   });

--- a/index.test.js
+++ b/index.test.js
@@ -43,7 +43,7 @@ describe("buildStylesheet", () => {
       .fraunces-lightopmin *,
       .fraunces-lightopmin *::before,
       .fraunces-lightopmin *::after {
-          font-family: "Fraunces-LightOpMin", monospace;
+          font-family: "Fraunces-LightOpMin", var(--specimen-fallback-font, monospace), monospace;
           font-variation-settings: "opsz" var(--opsz),"wght" var(--wght),"WONK" var(--WONK);
       }
     `);


### PR DESCRIPTION
This way a specimen author can set a variable to use in the
specimen font stack. This can be used to catch characters that
somehow aren't in the specimen's font. (E.g. when a user types
a character that's not supported)

An author could decide to show the unsupported characters in a font
like Adobe NotDef (https://github.com/adobe-fonts/adobe-notdef/)

Note that monospace is added twice: once as fallback for when
the CSS variable is undefined, once as ultimate fallback (mostly
to satisfy the linter).